### PR TITLE
fix: delete use of undefined function "total_cost"

### DIFF
--- a/bom.py
+++ b/bom.py
@@ -69,7 +69,6 @@ for group in grouped:
         c.getField("Vendor"),
         c.getField("Link"),
         c.getField("Unit"),
-        total_cost(c.getField("Unit"), len(group)),
         c.getField("MOQ"),
         c.getPartName() + ": " + c.getDescription(),
         dnp,


### PR DESCRIPTION
Was getting an error:

```
Traceback (most recent call last):
  File "/home/kaspar/projects/kitspace/boards/oak/scripts/bom.py", line 72, in <module>
    total_cost(c.getField("Unit"), len(group)),
NameError: name 'total_cost' is not defined
```
