### PR TITLE
feat: use "Qty" heading for the BOM quantity column

### DIFF
--- a/bom.py
+++ b/bom.py
@@ -28,7 +28,7 @@ def get_datasheet(datasheet):
 out.writerow([
     'Designator',  # E.g. U1, R1
     'Value',  # E.g. 10k, 0.1uF
-    'Q',  # Quantity of each part
+    'Qty',  # Quantity of each part
     'Package',  # E.g. SMD, 0805, SOT-23-5
     'Category',  # E.g. Electronics, Connector, Mechanical, PCB
     'Stock',  # Internal stock location

--- a/bom.py
+++ b/bom.py
@@ -69,7 +69,6 @@ for group in grouped:
         c.getField("Vendor"),
         c.getField("Link"),
         c.getField("Unit"),
-        total_cost(c.getField("Unit"), len(group)),
         c.getField("MOQ"),
         c.getPartName() + ": " + c.getDescription(),
         dnp,


### PR DESCRIPTION
This is for compatibility with how we read BOMs on https://kitspace.org

I made a merge request to add the meta-data for adding the Oak project: https://github.com/hutscape/oak/pull/21